### PR TITLE
Add correct path of darktheme.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install ng-bootstrap-darkmode bootstrap-darkmode
 Include darkmode css (in `styles.scss`):
 
 ```scss
-@import "~bootstrap-darkmode/darktheme";
+@import "~bootstrap-darkmode/scss/darktheme";
 ```
 
 Alternatively, if you are not using SCSS, add the following in `angular.json` under `projects.<yourProject>.architect.build.options.styles`:


### PR DESCRIPTION
## Description
I've tried to implement `ng-bootstrap-darkmode` in one of my projects and noticed that the path you suggest in your `README.md` seems to be wrong. I also had a look into your `bootstrap-darkmode` project, but it seems, that you already suggest the correct path there.

## References
* [bootstrap-darkmode](https://github.com/Clashsoft/bootstrap-darkmode)